### PR TITLE
Added Percentages to ServerTopQueries

### DIFF
--- a/ServerTopQueries/3-dbo.vServerTopQueriesIndex.View.sql
+++ b/ServerTopQueries/3-dbo.vServerTopQueriesIndex.View.sql
@@ -28,6 +28,10 @@
 --		[Measurement]			NVARCHAR(32)	NOT NULL
 --			Measurement to order the queries on
 --
+--		[Percentages]			BIT				NOT NULL
+--			Flag to determine whether the values are "percentages"
+--			When enabled, the [Measurement] values will go from 0 to 100000 (equivalent to 0% to 100%)
+--
 --		[IncludeQueryText]		BIT				NOT NULL
 --			Flag to include the Query Text in the results generated
 --
@@ -48,6 +52,10 @@
 -- Date: 2021.08.25
 -- Auth: Pablo Lozano (@sqlozano)
 -- Changes: Removed parameters: @ExecutionRegular, @ExecutionAborted, @ExecutionException after removing them from the procedure
+--
+-- Date: 2021.10.15
+-- Auth: Pablo Lozano (@sqlozano)
+-- Changes: Added parameter: @Percentages
 ----------------------------------------------------------------------------------
 
 CREATE OR ALTER VIEW [dbo].[vServerTopQueriesIndex]
@@ -61,6 +69,7 @@ SELECT
 	,q.n.value('EndTime[1]',			'DATETIME2')		AS [EndTime] 
 	,q.n.value('Top[1]',				'INT')				AS [Top]
 	,q.n.value('Measurement[1]',		'NVARCHAR(32)')		AS [Measurement]
+	,q.n.value('Percentages[1]',		'BIT')				AS [Percentages]
 	,q.n.value('IncludeQueryText[1]',	'BIT')				AS [IncludeQueryText]
 	,q.n.value('ExcludeAdhoc[1]',		'BIT')				AS [ExcludeAdhoc]
 	,q.n.value('ExcludeInternal[1]',	'BIT')				AS [ExcludeInternal]

--- a/ServerTopQueries/4-dbo.vServerTopQueriesStore.View.sql
+++ b/ServerTopQueries/4-dbo.vServerTopQueriesStore.View.sql
@@ -71,6 +71,10 @@
 -- Date: 2021.08.19
 -- Auth: Pablo Lozano (@sqlozano)
 -- Changes: Modified view to replace [PlanID] with [MinNumberPlans]
+--
+-- Date: 2021.10.15
+-- Auth: Pablo Lozano (@sqlozano)
+-- Changes: Added column [Percentages] for new parameter @Percentages
 ----------------------------------------------------------------------------------
 
 CREATE OR ALTER VIEW [dbo].[vServerTopQueriesStore]
@@ -80,6 +84,7 @@ SELECT
 	,[stqi].[CaptureDate]
 	,[stqi].[ServerIdentifier]
 	,[stqi].[Measurement]
+	,[stqi].[Percentages]
 	,[stqs].[DatabaseName]
 	,[stqs].[QueryID]
 	,[stqs].[MinNumberPlans]

--- a/ServerTopQueries/README.md
+++ b/ServerTopQueries/README.md
@@ -3,8 +3,19 @@ This tool provides uses the runtime stats for each database on the server to get
 \
 (SQL 2016 does not support @Measurement = 'log_bytes_used' / 'tempdb_space_used')
 ## Use cases and examples
-### Queries with a high CPU consumption
+### Queries with a high CPU consumption (results in microseconds)
 Get a list of queries (top 10 per database) along with their query text, aggregating all exit results of the queries
+```
+EXECUTE [dbo].[ServerTopQueries]
+	 @Measurement 		= 	'cpu_time'
+	,@Top 			= 	10
+	,@AggregateAll		=	1
+	,@IncludeQueryText 	= 	1
+```
+### Queries with a high CPU consumption (results in percentage)
+Get a list of queries (top 10 per database) along with their query text, aggregating all exit results of the queries
+The measurements, rather than be measured in their corresponding units (microseconds, 8 KB pages, or log bytes), will be returned in a 0 to 100000 range
+This is done rather than returning a DECIMAL value so that the BIGINT measurement columns in the [dbo].[ServerTopQueries] table can be reused.
 ```
 EXECUTE [dbo].[ServerTopQueries]
 	 @Measurement 		= 	'cpu_time'


### PR DESCRIPTION
ServerTopQueries can return a 0-100000 value indicating the amount of cpu/duration/io.... per query compared to the total usage found in all the server's query store data.
This does not include activity on the databases with no query store enabled, so will not be 100% accurate